### PR TITLE
Fix survey progress, challenge navigation, and cookie banner persistence

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -282,11 +282,17 @@ body {
 
 /* Challenge Assignment */
 .challenge-assignment {
-  animation: fadeInOut 2.25s ease;
+  animation: fadeInOut 3.5s ease;
+  animation-fill-mode: forwards;
   font-size: 3.125rem;
   font-weight: bold;
   letter-spacing: 2px;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
 }
 
 /* Challenge Text Screen */

--- a/src/App.js
+++ b/src/App.js
@@ -89,75 +89,70 @@ function AppContent() {
 
   // Challenge data structure
   const challengeSets = {
-    'Beach/Park': [
-      'Sit and take in nature and the sounds around you for 15 minutes, without checking your phone',
-      'Pay a stranger a genuine compliment',
-      'Throw away a couple pieces of trash, even if they\'re not yours',
+    'Beach / Park / Public Spaces': [
+      'Sit in stillness for 15 minutes. No phone, no music—just observe your surroundings.',
+      'Offer a stranger a sincere compliment—make it personal, not performative.',
+      'Pick up and dispose of at least two pieces of litter that aren\'t yours',
       'Strike up a meaningful conversation with someone who is clearly outside your demographic',
-      'Exist without distractions for 30 minutes, no phone, no music, just observe your environment or enjoy nature',
-      'Give up your personal comfort: pick up a piece of trash, give up your seat, help someone who looks like they can use it.',
-      'Hold the door for 3 different people today'
+      'Spend 30 minutes without looking at your phone. Be fully present in your environment.',
+      'Hold the door open for three different people today.'
     ],
-    'Coffee Shop/Library': [
-      'Create a mini plan today for a goal you\'ve been delaying',
-      'Start a conversation with a stranger, ask them how their day is going',
-      'Journal when you get home today',
+    'Coffee Shop / Library': [
+      'Map out a realistic step-by-step plan for a goal you\'ve been avoiding.',
+      'Initiate a conversation with someone nearby—ask how their day is going.',
+      'Journal about your day when you get the chance',
       'Take a cold shower today',
-      'Do not complain about anything for the whole day tomorrow',
-      'Stay off of all social media for the rest of today',
-      'Stay off your phone until you finish one of your tasks that you came here to complete',
-      'Start working on a business idea you\'ve had, or try to come up with one to start working on',
-      'Physically write out your plan towards a goal of yours',
-      'Draw out an idea that you\'ve had recently for a product or service',
-      'Set a new goal for yourself',
-      'Make plans for how you will achieve your current goals'
+      'Stay off all social media until your current task is complete.',
+      'Do not touch your phone until you\'ve finished at least one planned task.',
+      'Start working on a business idea you\'ve been sitting on—or draft a brand new one.',
+      'Write out your plan towards a meaningful goal of yours.',
+      'Sketch out a product or service idea you\'ve been thinking about.',
+      'Define a new goal for yourself in writing—be specific.'
     ],
-    'Fitness Class (Yoga, HIIT, Spin, Pilates)': [
-      'Sit still for 5 minutes after class with your eyes closed and take a moment for yourself',
-      'Hold your hardest pose 10 seconds longer than you want to',
-      'Ask your instructor what they think you should focus on most',
-      'Take 10 minutes after class to practice your hardest pose',
-      'Compliment someone in class on their practice',
-      'Set a new goal for your practice',
-      'Plan out how you should achieve your current goals for your practice',
-      'Attend a class that you are intimidated by or generally avoid'
+    'Fitness Class (Yoga, Spin, Pilates, HIIT)': [
+      'After class, sit with your eyes closed for 5 minutes and be in the moment.',
+      'Choose your most difficult pose and hold it 10 seconds longer than you want to.',
+      'Ask your instructor to identify one area where you can improve.',
+      'Spend 10 minutes post-class practicing the pose you struggle with most.',
+      'Push yourself a little harder than usual in today\'s class.',
+      'Genuinely compliment a classmate\'s effort or progress today.',
+      'Set a new goal for your practice, workout or fitness journey.',
+      'Create a clear plan to achieve your current fitness goal.',
+      'Attend a class you\'ve been hesitant to try due to discomfort or fear.'
     ],
     'Martial Arts Gym': [
-      'Stay after class and drill what you learned today',
-      'Roll with at least two higher belts today',
-      'Show up to the next class 15 minutes early',
-      'Thank all of your coaches after class today',
-      'Ask your trainers what you can be doing better with your technique',
-      'Ask to roll with your coach',
-      'Commit to a goal in your training and write down the steps you\'ll take to reach it'
+      'Stay after class to drill today\'s techniques for at least 10 minutes.',
+      'Roll with two higher belts today.',
+      'Thank each of your coaches after class today.',
+      'Ask a coach for direct feedback on where you can improve technically.',
+      'Ask to roll with your coach today.',
+      'Set a goal for yourself and write down steps on how you plan to reach it.'
     ],
-    'Movies/Mall/Bowling/Arcade/Theme Park': [
-      'Sit and take in nature and the sounds around you for 15 minutes, without checking your phone',
-      'Pay a stranger a genuine compliment',
-      'Throw away a couple pieces of trash, even if they\'re not yours',
+    'Movies / Mall / Bowling / Arcade / Theme Park': [
+      'Sit in silence for 15 minutes in a public space—no phone, no distractions. Just observe.',
+      'Offer a stranger a genuine compliment that takes effort to say.',
+      'Pick up and throw away two pieces of trash, even if they\'re not yours.',
       'Strike up a meaningful conversation with someone who is clearly outside your demographic',
-      'Exist without distractions for 30 minutes, no phone, no music, just observe your environment or enjoy nature',
-      'Give up your personal comfort: pick up a piece of trash, give up your seat, help someone who looks like they can use it.',
-      'Hold the door for 3 different people today'
+      'Spend 30 minutes without any form of digital input. Just exist.',
+      'Hold the door open for three different people today'
     ],
     'Office': [
-      'Do the hardest task on your list first thing today',
-      'Turn off your notifications for 1 hour and do deep work',
-      'Thank someone for their help this week, in person',
-      'Plan tomorrow\'s 3 \'must-do\' tasks before leaving the office today',
-      'Avoid drinking coffee today',
-      'Write down 1 way that you can improve in the office and what you can do to implement it'
+      'Begin your day by tackling the task you\'ve been avoiding most.',
+      'Disable all notifications and commit to one hour of deep, uninterrupted work.',
+      'Thank someone face-to-face for their contribution to your week.',
+      'Write down the three critical tasks for tomorrow before leaving today.',
+      'Avoid drinking any caffeine today.',
+      'Identify one habit or action that would make you more effective at work—and take the first step toward it today.'
     ],
     'Weightlifting Gym': [
-      'Spend 10 minutes stretching after your workout',
-      'Take a cold shower today',
-      'Avoid looking at your phone this workout',
-      'Complete an extra set on each workout today',
-      'Do 10 minutes on the stair master before or after your workout today',
-      'Do a 10 minute light jog on the treadmill before or after your workout',
-      'Rep your next exercise until failure, real failure',
-      'Commit to a goal in the gym and write down steps you\'ll take to achieve it',
-      'Workout with no music today'
+      'Spend at least 10 minutes stretching post-workout.',
+      'Take a cold shower after your workout.',
+      'Stay off your phone this entire workout',
+      'Add one set to every workout today.',
+      'Begin or end your workout with 10 minutes on the stairmaster—no excuses.',
+      'Add a 10-minute light jog to your routine today—before or after lifting.',
+      'Complete your next workout to failure, real failure.',
+      'Write down a specific fitness goal and the exact plan you\'ll follow to reach it.'
     ]
   };
 
@@ -250,11 +245,13 @@ function AppContent() {
         if (savedAnswers) {
           setAnswers(JSON.parse(savedAnswers));
         }
-        if (savedCurrentQuestion) {
+        if (savedCurrentQuestion && savedCurrentQuestion !== 'challenge') {
           setCurrentQuestion(parseInt(savedCurrentQuestion));
         }
-        // Show challenge assignment screen if user was in progress
-        if (savedCurrentQuestion && parseInt(savedCurrentQuestion) === 0) {
+        if (savedCurrentQuestion === 'challenge') {
+          setShowSurvey(true);
+          setShowChallengeText(true);
+        } else if (savedCurrentQuestion && parseInt(savedCurrentQuestion) === 0) {
           setShowSurvey(true);
           setShowChallengeAssignment(true);
           setChallengeFadeIn(true);
@@ -265,6 +262,35 @@ function AppContent() {
       setHasError(true);
     }
   }, [navigate]);
+
+  const CookieBanner = () => (
+    <div className="cookie-banner-popup">
+      <div className="cookie-popup-content">
+        <h4>We Use Cookies</h4>
+        <p>
+          We use cookies to enhance your experience and analyze site usage.
+          By continuing to use our site, you consent to our use of cookies.
+        </p>
+        <div className="cookie-popup-buttons">
+          <button className="cookie-popup-btn accept" onClick={acceptCookies}>
+            Accept All
+          </button>
+          <button className="cookie-popup-btn necessary" onClick={acceptNecessaryCookies}>
+            Necessary Only
+          </button>
+          <button className="cookie-popup-btn decline" onClick={declineCookies}>
+            Decline All
+          </button>
+        </div>
+        <button
+          className="cookie-popup-link"
+          onClick={() => { setShowPrivacy(true); setActiveTab('cookies'); navigate('/privacy'); }}
+        >
+          Learn more
+        </button>
+      </div>
+    </div>
+  );
 
   // Cleanup submitted timer on unmount
   useEffect(() => {
@@ -303,6 +329,12 @@ function AppContent() {
       setSelectedFile(null);
       setShowCheckmark(false);
       setErrors({});
+
+      // Clear any stored progress when returning home
+      localStorage.removeItem('stepZeroLocation');
+      localStorage.removeItem('stepZeroChallenge');
+      localStorage.removeItem('stepZeroAnswers');
+      localStorage.removeItem('stepZeroCurrentQuestion');
     } else if (path.startsWith('/thank-you/')) {
       // Thank you page
       const thankYouTypeFromPath = path.split('/')[2];
@@ -386,14 +418,32 @@ function AppContent() {
 
 
   const startSurvey = () => {
+    // Reset any previously saved progress
+    setCurrentQuestion(0);
+    setSelectedLocation('');
+    setAssignedChallenge('');
+    setChallengeCompleted(null);
+    setAnswers({});
+    setShowOtherSection(false);
+    setShowOtherSection5a(false);
+    setShowEmailSection(false);
+    setShowMediaSection(false);
+    setSelectedFile(null);
+    setShowCheckmark(false);
+    setErrors({});
+    localStorage.removeItem('stepZeroLocation');
+    localStorage.removeItem('stepZeroChallenge');
+    localStorage.removeItem('stepZeroAnswers');
+    localStorage.removeItem('stepZeroCurrentQuestion');
+
     // Reset final question submitted state
     setFinalQuestionSubmitted(false);
-    
+
     // Check if survey was completed and if enough time has passed (1 minute)
     const surveyCompletionTime = localStorage.getItem('surveyCompletionTime');
     const currentTime = Date.now();
     const oneMinute = 60 * 1000; // 60 seconds in milliseconds
-    
+
     if (surveyCompleted && surveyCompletionTime && (currentTime - parseInt(surveyCompletionTime)) < oneMinute) {
       // If survey was completed less than 1 minute ago, show the appropriate thank you page
       // But only if it wasn't completed via "Not Interested" - in that case, start fresh
@@ -404,42 +454,51 @@ function AppContent() {
         return;
       }
     }
-    
+
     // Clear any existing timer
     if (timerRef.current) {
       clearTimeout(timerRef.current);
       timerRef.current = null;
     }
-    
+
     setShowSurvey(true);
-    setShowLocationSelection(true);
+    // Delay showing the first question so the progress bar can animate
+    setShowLocationSelection(false);
     setShowChallengeAssignment(false);
-    setSelectedLocation('');
-    setAssignedChallenge('');
     setSurveyHidden(false);
+    setTimeout(() => setShowLocationSelection(true), 50);
   };
 
   const showNotInterested = () => {
-    // If we're in the challenge text screen, go back to location selection
     if (showChallengeText) {
-      setShowChallengeText(false);
-      setShowLocationSelection(true);
+      setPreviousPage('challenge');
+    } else {
+      setPreviousPage('hero');
+    }
+
+    setShowChallengeText(false);
+    setShowSurvey(false);
+    setShowThankYou(true);
+    setThankYouType('not-interested');
+    setLastThankYouType('not-interested');
+    setSurveyCompleted(true);
+    localStorage.setItem('surveyCompleted', 'true');
+    localStorage.setItem('lastThankYouType', 'not-interested');
+    localStorage.setItem('surveyCompletionTime', Date.now().toString());
+    navigate('/thank-you/not-interested');
+  };
+
+  const handleNotInterestedBack = () => {
+    if (previousPage === 'challenge') {
+      setShowThankYou(false);
       setShowSurvey(true);
-      setCurrentQuestion(0);
-      setSelectedLocation('');
-      setAssignedChallenge('');
+      setShowChallengeText(true);
+      setShowChallengeAssignment(false);
+      setPreviousPage('');
+      localStorage.setItem('stepZeroCurrentQuestion', 'challenge');
       navigate('/survey/location');
     } else {
-      // Otherwise show the "not-interested" thank you page
-      setShowSurvey(false);
-      setShowThankYou(true);
-      setThankYouType('not-interested');
-      setLastThankYouType('not-interested');
-      setSurveyCompleted(true);
-      localStorage.setItem('surveyCompleted', 'true');
-      localStorage.setItem('lastThankYouType', 'not-interested');
-      localStorage.setItem('surveyCompletionTime', Date.now().toString());
-      navigate('/thank-you/not-interested');
+      goBackToMain();
     }
   };
 
@@ -477,9 +536,11 @@ function AppContent() {
 
   const goBack = () => {
     if (currentQuestion === 1) {
-      setShowChallengeAssignment(true);
-      setChallengeFadeIn(true);
+      setShowChallengeText(true);
+      setShowChallengeAssignment(false);
+      setChallengeFadeIn(false);
       setCurrentQuestion(0);
+      localStorage.setItem('stepZeroCurrentQuestion', 'challenge');
       navigate('/survey/location');
     } else if (currentQuestion === 2) {
       setCurrentQuestion(1);
@@ -536,25 +597,34 @@ function AppContent() {
   };
 
   const updateProgress = () => {
-    let progress = 0;
-    if (showThankYou && thankYouType !== 'not-interested') progress = 100;
-    else if (showLocationSelection) progress = 10;
-    else if (showChallengeAssignment) progress = 20;
-    else if (showChallengeText) progress = 25;
-    else if (currentQuestion === 1) progress = 30;
-    else if (currentQuestion === 3) progress = 40;
-    else if (currentQuestion === '4a') progress = 50;
-    else if (currentQuestion === '5a') progress = 60;
-    else if (currentQuestion === '5c') progress = 70;
-    else if (currentQuestion === '4b') progress = 50;
-    else if (currentQuestion === '4b-other') progress = 55;
-    else if (currentQuestion === '5b') progress = 60;
-    else if (currentQuestion === '5b-email') progress = 65;
-    else if (currentQuestion === 6) progress = 75;
-    else if (currentQuestion === 7) progress = 85;
-    else if (currentQuestion === 8) progress = 100;
-    else if (showSurvey && !showLocationSelection && !showChallengeAssignment && !showChallengeText && currentQuestion === 0) progress = 5;
-    return progress;
+    const totalSteps = 10;
+    let step = 0;
+
+    if (showThankYou) {
+      step = thankYouType !== 'not-interested' ? totalSteps : 0;
+    } else if (showChallengeText) step = 3;
+    else if (showChallengeAssignment || assignedChallenge) step = 2;
+    else if (showLocationSelection) step = 1;
+    else if (currentQuestion === 1) step = 4;
+    else if (currentQuestion === 3) step = 5;
+    else if (
+      currentQuestion === '4a' ||
+      currentQuestion === '4b' ||
+      currentQuestion === '4b-other'
+    )
+      step = 6;
+    else if (
+      currentQuestion === '5a' ||
+      currentQuestion === '5c' ||
+      currentQuestion === '5b' ||
+      currentQuestion === '5b-email'
+    )
+      step = 7;
+    else if (currentQuestion === 6) step = 8;
+    else if (currentQuestion === 7) step = 9;
+    else if (currentQuestion === 8) step = 10;
+
+    return (step / totalSteps) * 100;
   };
 
   const validateAndContinue = (questionNumber, suffix = '') => {
@@ -756,20 +826,30 @@ function AppContent() {
       setShowChallengeAssignment(true);
       setChallengeFadeIn(true);
       
-      // Auto-fade out after 2.25 seconds (like the old intro)
+      // Auto-fade out after 3.5 seconds so users can read the intro
       const timer = setTimeout(() => {
         setChallengeFadeIn(false);
         setTimeout(() => {
           setShowChallengeAssignment(false);
           setShowChallengeText(true);
         }, 300);
-      }, 2250);
+      }, 3500);
       
       setChallengeAssignmentTimer(timer);
     }, 300);
   };
 
 
+
+  const backToLocation = () => {
+    setShowChallengeText(false);
+    setShowLocationSelection(true);
+    setSelectedLocation('');
+    setAssignedChallenge('');
+    localStorage.removeItem('stepZeroLocation');
+    localStorage.removeItem('stepZeroChallenge');
+    localStorage.removeItem('stepZeroCurrentQuestion');
+  };
 
   const continueToSurvey = () => {
     setShowChallengeText(false);
@@ -1144,10 +1224,11 @@ function AppContent() {
 
   if (showThankYou) {
     return (
-      <div className="container">
-        <div className="nav-bar">
-          <div className="nav-links">
-            <button ref={homeBtnRef} className="nav-btn" onClick={goBackToMain}>Home</button>
+      <>
+        <div className="container">
+          <div className="nav-bar">
+            <div className="nav-links">
+              <button ref={homeBtnRef} className="nav-btn" onClick={goBackToMain}>Home</button>
             <button
               ref={aboutBtnRef}
               className="nav-btn"
@@ -1164,15 +1245,17 @@ function AppContent() {
             <div className="nav-indicator" style={indicatorStyle}></div>
           </div>
         </div>
-        <div className="progress-bar">
-          <div className="progress-fill" style={{ width: `${updateProgress()}%` }}></div>
-        </div>
+        {thankYouType !== 'not-interested' && (
+          <div className="progress-bar">
+            <div className="progress-fill" style={{ width: `${updateProgress()}%` }}></div>
+          </div>
+        )}
         <div className="thank-you-page">
           {thankYouType === 'not-interested' && (
             <>
               <h2>Got it.</h2>
               <p>Be sure to keep up with our socials in case you change your mind!</p>
-              <button className="not-interested-btn" onClick={goBackToMain} style={{ marginTop: '5px', marginBottom: '7.5px' }}>
+              <button className="not-interested-btn" onClick={handleNotInterestedBack} style={{ marginTop: '5px', marginBottom: '7.5px' }}>
                 Go Back
               </button>
               <button className="not-interested-btn" onClick={() => { setPreviousPage('not-interested'); setShowThankYou(false); setShowAbout(true); navigate('/about'); }} style={{ marginTop: '5px', marginBottom: '7.5px' }}>
@@ -1264,13 +1347,17 @@ function AppContent() {
           </div>
         </div>
       </div>
-    );
+    </div>
+    {showCookieBanner && <CookieBanner />}
+  </>
+  );
   }
 
   if (showPrivacy) {
     return (
-      <div className="container">
-        <div className="nav-bar">
+      <>
+        <div className="container">
+          <div className="nav-bar">
           <div className="nav-links">
             <button ref={homeBtnRef} className="nav-btn" onClick={goBackToMain}>Home</button>
             <button
@@ -1531,24 +1618,27 @@ function AppContent() {
             <span>© Step Zero, Inc 2025</span>
           </div>
         </div>
-      </div>
+        </div>
+        {showCookieBanner && <CookieBanner />}
+      </>
     );
   }
 
   if (showAbout) {
     return (
-      <div className="container">
-        <div className="nav-bar">
-          <div className="nav-links">
-            <button ref={homeBtnRef} className="nav-btn" onClick={goBackToMain}>Home</button>
-            <button ref={aboutBtnRef} className="nav-btn">About</button>
-            <button className="nav-btn" style={{ opacity: 0.5, cursor: 'default' }}>Foundations</button>
-            <div className="nav-indicator" style={indicatorStyle}></div>
+      <>
+        <div className="container">
+          <div className="nav-bar">
+            <div className="nav-links">
+              <button ref={homeBtnRef} className="nav-btn" onClick={goBackToMain}>Home</button>
+              <button ref={aboutBtnRef} className="nav-btn">About</button>
+              <button className="nav-btn" style={{ opacity: 0.5, cursor: 'default' }}>Foundations</button>
+              <div className="nav-indicator" style={indicatorStyle}></div>
+            </div>
           </div>
-        </div>
-        <div className="about-page">
-                        <h2>About Us</h2>
-          <div className="about-content">
+          <div className="about-page">
+            <h2>About Us</h2>
+            <div className="about-content">
             <p>
               Step Zero is a movement created to push people to become the best version of themselves 
               by confronting them with challenges that they may naturally avoid, delay or not think about altogether. We believe 
@@ -1630,6 +1720,8 @@ function AppContent() {
           </div>
         </div>
       </div>
+      {showCookieBanner && <CookieBanner />}
+      </>
     );
   }
 
@@ -1688,35 +1780,7 @@ function AppContent() {
             </div>
           </div>
           
-          {/* Cookie Banner Popup */}
-          {showCookieBanner && (
-            <div className="cookie-banner-popup">
-              <div className="cookie-popup-content">
-                <h4>We Use Cookies</h4>
-                <p>
-                  We use cookies to enhance your experience and analyze site usage. 
-                  By continuing to use our site, you consent to our use of cookies.
-                </p>
-                <div className="cookie-popup-buttons">
-                  <button className="cookie-popup-btn accept" onClick={acceptCookies}>
-                    Accept All
-                  </button>
-                  <button className="cookie-popup-btn necessary" onClick={acceptNecessaryCookies}>
-                    Necessary Only
-                  </button>
-                  <button className="cookie-popup-btn decline" onClick={declineCookies}>
-                    Decline All
-                  </button>
-                </div>
-                <button 
-                  className="cookie-popup-link"
-                  onClick={() => { setShowCookieBanner(false); setShowPrivacy(true); setActiveTab('cookies'); navigate('/privacy'); }}
-                >
-                  Learn more
-                </button>
-              </div>
-            </div>
-          )}
+          {showCookieBanner && <CookieBanner />}
         </>
       )}
 
@@ -1734,8 +1798,8 @@ function AppContent() {
             <div className="progress-fill" style={{ width: `${updateProgress()}%` }}></div>
           </div>
 
-          {(currentQuestion > 0 || typeof currentQuestion === 'string') && (
-            <button className="survey-exit-btn" onClick={goBackToMain}>
+          {!showChallengeAssignment && (
+            <button className="survey-exit-btn fade-in" onClick={goBackToMain}>
               ×
             </button>
           )}
@@ -1752,11 +1816,11 @@ function AppContent() {
                     key={`location-${shakeTrigger}`}
                   >
                     <option value="">Select location</option>
-                    <option value="Beach/Park">Beach/Park</option>
-                    <option value="Coffee Shop/Library">Coffee Shop/Library</option>
-                    <option value="Fitness Class (Yoga, HIIT, Spin, Pilates)">Fitness Class (Yoga, HIIT, Spin, Pilates)</option>
+                    <option value="Beach / Park / Public Spaces">Beach / Park / Public Spaces</option>
+                    <option value="Coffee Shop / Library">Coffee Shop / Library</option>
+                    <option value="Fitness Class (Yoga, Spin, Pilates, HIIT)">Fitness Class (Yoga, Spin, Pilates, HIIT)</option>
                     <option value="Martial Arts Gym">Martial Arts Gym</option>
-                    <option value="Movies/Mall/Bowling/Arcade/Theme Park">Movies/Mall/Bowling/Arcade/Theme Park</option>
+                    <option value="Movies / Mall / Bowling / Arcade / Theme Park">Movies / Mall / Bowling / Arcade / Theme Park</option>
                     <option value="Office">Office</option>
                     <option value="Weightlifting Gym">Weightlifting Gym</option>
                   </select>
@@ -1787,10 +1851,10 @@ function AppContent() {
                 <div className="challenge-text">
                   {assignedChallenge}
                 </div>
-                <div className="challenge-instructions">
-                  <p>Complete this challenge, then return to this page to continue the survey.</p>
-                </div>
                 <div className="button-container">
+                  <button className="back-btn small" onClick={backToLocation}>
+                    Back
+                  </button>
                   <button className="back-btn small" onClick={showNotInterested}>
                     Not Interested
                   </button>
@@ -2334,7 +2398,6 @@ function AppContent() {
               )}
             </div>
           )}
-          </div>
 
           <div className="bottom-footer">
             <div className="copyright-footer">


### PR DESCRIPTION
## Summary
- Hide progress bar when users opt out and exclude Not Interested pages from progress calculations
- Smoothly fade out the challenge intro screen and add exit button to challenge page
- Keep cookie consent banner visible on all pages until the user chooses an option
- Refresh challenge sets and location options with updated tasks
- Remove stray closing div in footer that caused JSX parse error

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tsutils)*
- `npm run build` *(fails: react-scripts: not found)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aba683db648329ae36dd7aed283891