### PR TITLE
Parse age as integer when saving survey responses

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -691,7 +691,7 @@ function AppContent() {
             question5b_reminder: answers.question5b || '',
             question5b_email: answers['answer5b-email'] || '',
             question6_consent: answers.question6 || '',
-            question7_age: answers.age || '',
+            question7_age: answers.age ? parseInt(answers.age, 10) : null,
             question8_gender: answers.gender || '',
             terms_consent: termsConsent,
             completion_time: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- Ensure age is stored as an integer or null when saving survey data to Supabase.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68acc19ac18083298a5d42b39c6bfff0